### PR TITLE
Reconnect to all previous networks

### DIFF
--- a/container/client.go
+++ b/container/client.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
 	"golang.org/x/net/context"
 )
 
@@ -118,10 +119,11 @@ func (client dockerClient) StartContainer(c Container) error {
 	bg := context.Background();
 	config := c.runtimeConfig()
 	hostConfig := c.hostConfig()
+	networkConfig := &network.NetworkingConfig{EndpointsConfig: c.containerInfo.NetworkSettings.Networks}
 	name := c.Name()
 
 	log.Infof("Starting %s", name)
-	creation, err := client.api.ContainerCreate(bg, config, hostConfig, nil, name)
+	creation, err := client.api.ContainerCreate(bg, config, hostConfig, networkConfig, name)
 	if err != nil {
 		return err
 	}

--- a/container/client.go
+++ b/container/client.go
@@ -2,13 +2,13 @@ package container
 
 import (
 	"fmt"
-	"time"
 	"io/ioutil"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
-	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
+	dockerclient "github.com/docker/docker/client"
 	"golang.org/x/net/context"
 )
 
@@ -77,7 +77,7 @@ func (client dockerClient) ListContainers(fn Filter) ([]Container, error) {
 		}
 
 		c := Container{containerInfo: &containerInfo, imageInfo: &imageInfo}
-		if (fn(c)) {
+		if fn(c) {
 			cs = append(cs, c)
 		}
 	}
@@ -116,7 +116,7 @@ func (client dockerClient) StopContainer(c Container, timeout time.Duration) err
 }
 
 func (client dockerClient) StartContainer(c Container) error {
-	bg := context.Background();
+	bg := context.Background()
 	config := c.runtimeConfig()
 	hostConfig := c.hostConfig()
 	networkConfig := &network.NetworkingConfig{EndpointsConfig: c.containerInfo.NetworkSettings.Networks}
@@ -178,7 +178,7 @@ func (client dockerClient) IsContainerStale(c Container) (bool, error) {
 
 	if client.pullImages {
 		log.Debugf("Pulling %s for %s", imageName, c.Name())
-		
+
 		var opts types.ImagePullOptions // ImagePullOptions can take a RegistryAuth arg to authenticate against a private registry
 		auth, err := EncodedAuth(imageName)
 		if err != nil {
@@ -197,7 +197,7 @@ func (client dockerClient) IsContainerStale(c Container) (bool, error) {
 			return false, err
 		}
 		defer response.Close()
-		
+
 		// the pull request will be aborted prematurely unless the response is read
 		_, err = ioutil.ReadAll(response)
 	}
@@ -213,7 +213,6 @@ func (client dockerClient) IsContainerStale(c Container) (bool, error) {
 	} else {
 		log.Debugf("No new images found for %s", c.Name())
 	}
-	
 
 	return false, nil
 }

--- a/container/trust.go
+++ b/container/trust.go
@@ -2,8 +2,6 @@ package container
 
 import (
 	"errors"
-	"os"
-	"strings"
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/reference"
@@ -11,6 +9,8 @@ import (
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/cliconfig/configfile"
 	"github.com/docker/docker/cliconfig/credentials"
+	"os"
+	"strings"
 )
 
 /**
@@ -35,7 +35,7 @@ func EncodedEnvAuth(ref string) (string, error) {
 	username := os.Getenv("REPO_USER")
 	password := os.Getenv("REPO_PASS")
 	if username != "" && password != "" {
-		auth := types.AuthConfig {
+		auth := types.AuthConfig{
 			Username: username,
 			Password: password,
 		}
@@ -80,7 +80,7 @@ func ParseServerAddress(ref string) (string, error) {
 	}
 	parts := strings.Split(repository, "/")
 	return parts[0], nil
-	
+
 }
 
 // CredentialsStore returns a new credentials store based

--- a/container/util.go
+++ b/container/util.go
@@ -1,8 +1,5 @@
 package container
 
-import (
-)
-
 func sliceEqual(s1, s2 []string) bool {
 	if len(s1) != len(s2) {
 		return false
@@ -65,4 +62,3 @@ func structMapSubtract(m1, m2 map[string]struct{}) map[string]struct{} {
 
 	return m
 }
-

--- a/container/util_test.go
+++ b/container/util_test.go
@@ -63,4 +63,3 @@ func TestStructMapSubtract(t *testing.T) {
 	assert.Equal(t, map[string]struct{}{"a": x, "b": x, "c": x}, m1)
 	assert.Equal(t, map[string]struct{}{"a": x, "c": x}, m2)
 }
-


### PR DESCRIPTION
Hi,

This PR make watchtower reload the updated containers with all the previous network it was connected to. (very useful while updating containers launched by docker-compose for example, that are connected to db/backend networks and proxy/frontend networks)

I based my work on your fork because I hoped that you changing the docker client lib to the official would solve my problem automagically. It didn't… But that was already a potential big stepping stone that I was ready to make, and that I didn't have to do thanks to you! :+1: 